### PR TITLE
v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana-mobile/solana-mobile-expo-template",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",

--- a/src/utils/useMobileWallet.tsx
+++ b/src/utils/useMobileWallet.tsx
@@ -35,12 +35,14 @@ export function useMobileWallet() {
 
   const signAndSendTransaction = useCallback(
     async (
-      transaction: Transaction | VersionedTransaction
+      transaction: Transaction | VersionedTransaction,
+      minContextSlot: number,
     ): Promise<TransactionSignature> => {
       return await transact(async (wallet) => {
         await authorizeSession(wallet);
         const signatures = await wallet.signAndSendTransactions({
           transactions: [transaction],
+          minContextSlot,
         });
         return signatures[0];
       });


### PR DESCRIPTION
Changes
- Added a mandatory `minContextSlot` parameter to `signAndSendTransactions` due to a bug in Phantom wallet requiring this parameter.